### PR TITLE
dont use lazy map

### DIFF
--- a/src/farmhand/registry.clj
+++ b/src/farmhand/registry.clj
@@ -36,7 +36,7 @@
         items (.zrangeWithScores jedis reg-key ^Long start ^Long end)
         comparator (if newest-first? #(compare %2 %1) #(compare %1 %2))]
     (->> items
-         (map (fn [^Tuple tuple] {:expiration (long (.getScore tuple))
+         (mapv (fn [^Tuple tuple] {:expiration (long (.getScore tuple))
                                   :job (.getElement tuple)}))
          (sort-by :expiration comparator))))
 
@@ -56,7 +56,7 @@
     (let [fetcher #(update-in % [:job] (partial jobs/fetch context))
           reg-key (registry-key context reg-name)
           items (->> (page-raw jedis reg-key options)
-                     (map fetcher))
+                     (mapv fetcher))
           last-page (last-page jedis reg-key options)
           page (or page 0)]
       {:items items


### PR DESCRIPTION
I was hitting some some errors while refreshing the completed page, when having alot of submitted jobs.

Sometimes the job id would be the job array serialized ["status" "completed" ...].
Apparently mapv worked, but I don't now enough of redis to know why it solved.